### PR TITLE
assert matches regular expression

### DIFF
--- a/lib/Compat/v6/Assert/MatchesRegularExpression.php
+++ b/lib/Compat/v6/Assert/MatchesRegularExpression.php
@@ -1,0 +1,43 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+declare(strict_types=1);
+
+namespace RmpUp\PHPUnitCompat\Compat\v6\Assert;
+
+trait MatchesRegularExpression
+{
+	/**
+	 * @param string $pattern
+	 * @param string $string
+	 * @param string $message
+	 *
+	 * @deprecated Removed in phpUnit 10. Please use ::assertMatchesRegularExpression() instead.
+	 */
+	public static function assertRegExp($pattern, $string, $message = '')
+	{
+		parent::assertRegExp($pattern, $string, $message);
+	}
+
+	/**
+	 * @param string $pattern
+	 * @param string $string
+	 * @param string $message
+	 *
+	 * @deprecated Removed in phpUnit 10. Please use ::assertDoesNotMatchRegularExpression() instead.
+	 */
+	public static function assertNotRegExp($pattern, $string, $message = '')
+	{
+		parent::assertNotRegExp($pattern, $string, $message);
+	}
+
+	public static function assertMatchesRegularExpression($pattern, $string, string $message = '')
+	{
+		parent::assertRegExp($pattern, $string, $message);
+	}
+
+	public static function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = '')
+	{
+		self::assertNotRegExp($pattern, $string, $message);
+	}
+}

--- a/lib/Compat/v6/TestCase.php
+++ b/lib/Compat/v6/TestCase.php
@@ -22,11 +22,53 @@ declare(strict_types=1);
 
 namespace RmpUp\PHPUnitCompat\Compat\v6;
 
+use RmpUp\PHPUnitCompat\Compat\TestCaseTrait;
+
 /**
  * TestCase
  *
  * @copyright 2021 Pretzlaw (https://rmp-up.de)
  */
-class TestCase extends \RmpUp\PHPUnitCompat\Compat\v7\TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
+	use TestCaseTrait;
+
+	/**
+	 * Forward-compatibility
+	 */
+	use Assert\MatchesRegularExpression;
+
+	/**
+	 * Replacing
+	 *
+	 * @deprecated Please use ::compatSetUp() instead
+	 */
+	protected function setUp()
+	{
+		$this->compatSetUp();
+	}
+
+	/**
+	 * @deprecated Please use ::compatSetUpBeforeClass()
+	 */
+	public static function setUpBeforeClass()
+	{
+		static::compatSetUpBeforeClass();
+	}
+
+	/**
+	 * @deprecated Please use ::compatTearDown()
+	 */
+	protected function tearDown()
+	{
+		$this->compatTearDown();
+	}
+
+	/**
+	 * @deprecated Please use ::compatTearDownAfterClass()
+	 */
+	public static function tearDownAfterClass()
+	{
+		static::compatTearDownAfterClass();
+	}
 }

--- a/lib/Compat/v7/Assert/MatchesRegularExpression.php
+++ b/lib/Compat/v7/Assert/MatchesRegularExpression.php
@@ -1,0 +1,43 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+declare(strict_types=1);
+
+namespace RmpUp\PHPUnitCompat\Compat\v7\Assert;
+
+trait MatchesRegularExpression
+{
+	/**
+	 * @param string $pattern
+	 * @param string $string
+	 * @param string $message
+	 *
+	 * @deprecated Removed in phpUnit 10. Please use ::assertMatchesRegularExpression() instead
+	 */
+	public static function assertRegExp(string $pattern, string $string, $message = ''): void
+	{
+		parent::assertRegExp($pattern, $string, $message);
+	}
+
+	/**
+	 * @param string $pattern
+	 * @param string $string
+	 * @param string $message
+	 *
+	 * @deprecated Removed in phpUnit 10. Please use ::assertDoesNotMatchRegularExpression() instead.
+	 */
+	public static function assertNotRegExp(string $pattern, string $string, $message = ''): void
+	{
+		parent::assertNotRegExp($pattern, $string, $message);
+	}
+
+	public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+	{
+		parent::assertRegExp($pattern, $string, $message);
+	}
+
+	public static function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
+	{
+		self::assertNotRegExp($pattern, $string, $message);
+	}
+}

--- a/lib/Compat/v7/TestCase.php
+++ b/lib/Compat/v7/TestCase.php
@@ -34,8 +34,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
     use TestCaseTrait;
 
 	/**
-	 * Replacing 
-	 *
+	 * Forward-compatibility
+	 */
+    use Assert\MatchesRegularExpression;
+
+	/**
 	 * @deprecated Please use ::compatSetUp() instead
 	 */
     protected function setUp()
@@ -44,18 +47,24 @@ class TestCase extends \PHPUnit\Framework\TestCase
     }
 
 	/**
-	 * @deprecated Please use ::
+	 * @deprecated Please use ::compatSetUpBeforeClass()
 	 */
     public static function setUpBeforeClass()
     {
         static::compatSetUpBeforeClass();
     }
 
+	/**
+	 * @deprecated Please use ::compatTearDown()
+	 */
     protected function tearDown()
     {
         $this->compatTearDown();
     }
 
+	/**
+	 * @deprecated Please use ::compatTearDownAfterClass()
+	 */
     public static function tearDownAfterClass()
     {
         static::compatTearDownAfterClass();

--- a/lib/Compat/v8/TestCase.php
+++ b/lib/Compat/v8/TestCase.php
@@ -24,6 +24,7 @@ namespace RmpUp\PHPUnitCompat\Compat\v8;
 
 use PHPUnit\Util\InvalidArgumentHelper;
 use RmpUp\PHPUnitCompat\Compat\TestCaseTrait;
+use RmpUp\PHPUnitCompat\Compat\v7\Assert\MatchesRegularExpression;
 use RmpUp\PHPUnitCompat\Compat\v8\Assert\ArraySubset;
 
 /**
@@ -35,23 +36,47 @@ class TestCase extends \PHPUnit\Framework\TestCase
 {
     use TestCaseTrait;
 
+	/**
+	 * Backward-compatibility
+	 *
+	 * Note: This may become heavily opinionated some day
+	 * and very old methods may be dropped.
+	 * Fingers crossed that we can keep BC up for all of them.
+	 */
     use ArraySubset;
 
+	/**
+	 * Forward-compatibility
+	 */
+    use MatchesRegularExpression;
+
+	/**
+	 * @deprecated Please use ::compatSetUp() instead
+	 */
     protected function setUp(): void
     {
         $this->compatSetUp();
     }
 
+	/**
+	 * @deprecated Please use ::compatSetUpBeforeClass() instead.
+	 */
     public static function setUpBeforeClass(): void
     {
         static::compatSetUpBeforeClass();
     }
 
+	/**
+	 * @deprecated Please use ::compatTearDown() instead.
+	 */
     protected function tearDown(): void
     {
         $this->compatTearDown();
     }
 
+	/**
+	 * @deprecated Please use compatTearDownAfterClass() instead.
+	 */
     public static function tearDownAfterClass(): void
     {
         static::compatTearDownAfterClass();

--- a/lib/Compat/v9/TestCase.php
+++ b/lib/Compat/v9/TestCase.php
@@ -22,13 +22,57 @@ declare(strict_types=1);
 
 namespace RmpUp\PHPUnitCompat\Compat\v9;
 
+use RmpUp\PHPUnitCompat\Compat\TestCaseTrait;
 use RmpUp\PHPUnitCompat\Compat\v8\Assert\ArraySubset;
 
 /**
  * TestCase
  */
-class TestCase extends \RmpUp\PHPUnitCompat\Compat\v8\TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
+	use TestCaseTrait;
+
+	/**
+	 * Backward-compatibility
+	 *
+	 * Note: This may become heavily opinionated some day
+	 * and very old methods may be dropped.
+	 * Fingers crossed that we can keep BC up for all of them.
+	 */
+	use ArraySubset;
+
+	/**
+	 * @deprecated Please use ::compatSetUp() instead
+	 */
+	protected function setUp(): void
+	{
+		$this->compatSetUp();
+	}
+
+	/**
+	 * @deprecated Please use ::compatSetUpBeforeClass() instead.
+	 */
+	public static function setUpBeforeClass(): void
+	{
+		static::compatSetUpBeforeClass();
+	}
+
+	/**
+	 * @deprecated Please use ::compatTearDown() instead.
+	 */
+	protected function tearDown(): void
+	{
+		$this->compatTearDown();
+	}
+
+	/**
+	 * @deprecated Please use compatTearDownAfterClass() instead.
+	 */
+	public static function tearDownAfterClass(): void
+	{
+		static::compatTearDownAfterClass();
+	}
+
 	/**
 	 * @deprecated Use expectExceptionMessageMatches() instead
 	 */

--- a/lib/Versions.php
+++ b/lib/Versions.php
@@ -29,24 +29,34 @@ namespace RmpUp\PHPUnitCompat;
  */
 class Versions
 {
+	private static $version;
+
+	/**
+	 * List of classes last seen in the mapped PHPUnit version
+	 *
+	 * Those classes are all deprecated.
+	 * Their last occurrence tells us something about the PHPUnit version.
+	 *
+	 * @var int[]
+	 */
+	private static $classToVersion = [
+		\PHPUnit\Framework\BaseTestListener::class => 6,
+		\PHPUnit\Util\TestDox\TestResult::class => 7,
+		\PHPUnit\Util\Configuration::class => 8,
+		\PHPUnit\Util\Blacklist::class => 9
+	];
+
     public static function getPhpUnitVersion(): int
     {
-        if (class_exists(\PHPUnit\Framework\BaseTestListener::class)) {
-        	return 6;
+    	if (null === self::$version) {
+			foreach (self::$classToVersion as $className => $phpUnitVersion) {
+				if (class_exists($className)) {
+					self::$version = $phpUnitVersion;
+					break;
+				}
+			}
 		}
 
-        if (class_exists(\PHPUnit\Util\TestDox\TestResult::class)) {
-        	return 7;
-		}
-
-        if (class_exists(\PHPUnit\Util\Configuration::class)) {
-        	return 8;
-		}
-
-        if (class_exists(\PHPUnit\Util\Blacklist::class)) {
-        	return 9;
-		}
-
-        return 0;
+    	return self::$version;
     }
 }

--- a/opt/doc/TestCase/v10/MatchesRegularExpressionTest.php
+++ b/opt/doc/TestCase/v10/MatchesRegularExpressionTest.php
@@ -1,0 +1,24 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+declare(strict_types=1);
+
+namespace TestCase\v10;
+
+use RmpUp\PHPUnitCompat\TestCase;
+
+/**
+ * MatchesRegularExpressionTest
+ */
+class MatchesRegularExpressionTest extends TestCase
+{
+	public function testAssertMatchesRegularExpression()
+	{
+		static::assertMatchesRegularExpression('/wysiwyg/', 'wysiwyg');
+	}
+
+	public function testAssertDoesNotMatchRegularExpression()
+	{
+		static::assertDoesNotMatchRegularExpression('/wysiwyg/', uniqid('b', true));
+	}
+}


### PR DESCRIPTION
The assertion ::assertNotRegExp() will be renamed to
::assertMatchesRegularExpression() in v10.
We backport ::assertMatchesRegularExpression()
and offer a forward-compatibility from v6 on.

* marking assertRegExp as deprecated
  to show up the upcoming breaking change
* marking assertNotRegExp as deprecated
  to show up the upcoming breaking change